### PR TITLE
Bug fix for capturing json value & new options, beforeRequest and reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,53 @@ scenarios:
         namespace: /nsp1
 ```
 
+Respects `beforeRequest` custom function hook which is fired before emit
+```yml
+config:
+  processor: "./someFileWithSomeFunction.js"
+scenarios:
+  - engine: socketio-v3
+    flow:
+      - emit: ["join", "lobby"]
+        beforeRequest: "someFunction"
+```
+someFileWithSomeFunction.js
+```js
+function someFunction(requestParams, context, userEvents, next) {
+  // do something
+  return next();
+}
+```
+
+There is an option `reconnect` which can be used to force a socket reconnection before emit is fired.
+Use together with setting `extraHeaders` on the context object to enable login flows.
+```yml
+config:
+  processor: "./processor.js"
+scenarios:
+  - engine: socketio-v3
+    flow:
+      - emit: ["login", { username: "creds", password: "secretPword" }]
+        response:
+          channel: "success"
+          capture:
+            json: "$.token"
+            as: "token"
+      - function: "setToken"
+      - emit: ["join", "lobby"]
+        reconnect: true
+        namespace: /authorisedNamespace
+```
+
+processor.js
+```js
+function setToken(context, userEvents, next) {
+  context.extraHeaders = { 'x-auth-token': context.vars.token };
+  return next();  
+}
+```
+
+
 ### Install & Configure
 
 Install with npm

--- a/index.js
+++ b/index.js
@@ -259,14 +259,25 @@ SocketIoEngine.prototype.step = function (requestSpec, ee) {
     // Set default namespace in emit action
     requestSpec.namespace = template(requestSpec.namespace, context) || "";
 
-    self.loadContextSocket(requestSpec.namespace, context, function(err, socket) {
+    self.loadContextSocket(requestSpec.namespace, requestSpec.reconnect, context, function(err, socket) {
       if(err) {
         debug(err);
         ee.emit('error', err.message);
         return callback(err, context);
       }
-
-      return f(context, callback);
+      if(requestSpec.beforeRequest && self.config.processor[requestSpec.beforeRequest]) {
+        self.config.processor[requestSpec.beforeRequest](requestSpec,context,ee,function(err) {
+          if(err) {
+            debug(err);
+            ee.emit('error', err.message);
+            return callback(err, context);
+          } else {
+            return f(context, callback);
+          }
+        });
+      } else {
+        return f(context, callback);
+      }
     });
   }
 
@@ -277,14 +288,30 @@ SocketIoEngine.prototype.step = function (requestSpec, ee) {
   }
 };
 
-SocketIoEngine.prototype.loadContextSocket = function(namespace, context, cb) {
+SocketIoEngine.prototype.loadContextSocket = function(namespace, reconnect, context, cb) {
+  if(reconnect) {
+    // Disconnect all sockets
+    SocketIoEngine.prototype.closeContextSockets(context);
+  }
+
   context.sockets = context.sockets || {};
 
   if(!context.sockets[namespace]) {
     let target = this.config.target + namespace;
     let tls = this.config.tls || {};
 
-    const socketioOpts = template(this.socketioOpts, context);
+    const socketioOpts = template(
+      Object.assign({},this.socketioOpts,{
+        extraHeaders: {
+          ...this.socketioOpts.extraHeaders,
+          ...context.extraHeaders
+        },
+        // Require to force socket.io-client to set new headers on connection to different Namespace
+        forceNew: true,
+      }),
+      context
+    );
+
     let options = _.extend(
       {},
       socketioOpts, // templated
@@ -317,6 +344,7 @@ SocketIoEngine.prototype.closeContextSockets = function (context) {
       context.sockets[namespace].disconnect();
     });
   }
+  context.sockets = {};
 };
 
 
@@ -327,7 +355,7 @@ SocketIoEngine.prototype.compile = function (tasks, scenarioSpec, ee) {
   function zero(callback, context) {
     context.__receivedMessageCount = 0;
     ee.emit('started');
-    self.loadContextSocket('', context, function done(err) {
+    self.loadContextSocket('', false, context, function done(err) {
       if (err) {
         ee.emit('error', err);
         return callback(err, context);

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ function processResponse(ee, data, response, context, callback) {
 
         // Populate the context with captured values
         _.each(result.captures, function(v, k) {
-          context.vars[k] = v.value;
+          context.vars[k] = v.value ? v.value : v;
         });
       }
 


### PR DESCRIPTION
Hey Pablo

Thanks so much for creating this great plugin.  I recently needed to simulate a login flow so I added a reconnect option with the ability to set the extraHeaders config field via a processor before triggering the new connection.

Hopefully this is helpful!

I have a separate test project [here](https://github.com/gruffT/artillery-engine-socketio-v3-test) but I couldn't see an easy way to add testing to this library.

I hope this is useful and you would consider a merge.

Gareth